### PR TITLE
proguard config

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,8 @@ android {
         ndk {
             abiFilters 'armeabi-v7a', 'arm64-v8a'/*, 'x86', 'x86_64'*/
         }
+        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        consumerProguardFiles 'proguard-rules.pro'
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,3 @@
+-keep class com.docrecog.** { *; }
+-keep class com.accurascan.** { *; }
+-keep class com.inet.facelock.** { *; }


### PR DESCRIPTION
If you create a new Flutter project, from version 1.12 proguard is automatically enabled in build.gradle, this crashes the app