### PR TITLE
Disable sound

### DIFF
--- a/android/src/main/java/com/docrecog/scan/CameraActivity.java
+++ b/android/src/main/java/com/docrecog/scan/CameraActivity.java
@@ -1379,8 +1379,6 @@ public class CameraActivity extends SensorsActivity implements PlatformView, Met
 //            intent.putExtra("ocrData", application);
 //            startActivityForResult(intent, 101);
             mCardScanner.closeOCR(0);
-
-            playEffect();
         }
     }
 
@@ -1701,12 +1699,6 @@ public class CameraActivity extends SensorsActivity implements PlatformView, Met
                     = new Animator.AnimatorListener() {
 
                 public void onAnimationStart(Animator animation) {
-                    try {
-//                        mFlipImage.setVisibility(View.VISIBLE);
-                        playEffect();
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
                 }
 
                 public void onAnimationRepeat(Animator animation) {
@@ -2040,19 +2032,6 @@ public class CameraActivity extends SensorsActivity implements PlatformView, Met
 
     private boolean isCameraIdle() {
         return (mCameraState == IDLE || mFocusManager.isFocusCompleted());
-    }
-
-    void playEffect() {
-        if (audioManager != null)
-            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC), 0);
-        mediaPlayer.start();
-        mediaPlayer.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-            @Override
-            public void onCompletion(MediaPlayer mediaPlayer1) {
-//                mediaPlayer.stop();
-//                mediaPlayer.release();
-            }
-        });
     }
 
     //requesting the camera permission


### PR DESCRIPTION
* setting the volume to max without setting it back is such a bad experience, specially on devices that have loud speakers like tablets.
* on ios there is no sound, so why should android need it?
* the implementation of playing sounds can perfectly happen in flutter by the implementator, we for example only let the device give a haptic feedback with the build in functionality [HapticFeedback](https://api.flutter.dev/flutter/services/HapticFeedback/mediumImpact.html)