### PR TITLE
When this plugin is used the normal way the LIBRARY_SEARCH_PATHS is wrong

### DIFF
--- a/ios/accuraemirates.podspec
+++ b/ios/accuraemirates.podspec
@@ -24,7 +24,7 @@ A new Flutter plugin.
   s.xcconfig = {
     'OTHER_LDFLAGS' => '-framework opencv2 -lc++ -lAccuraFace -lAccuraEmirate -lz',
     'USER_HEADER_SEARCH_PATHS' => '"${PROJECT_DIR}/.."/**',
-    "LIBRARY_SEARCH_PATHS" => '"${PROJECT_DIR}/.."/**',
+    "LIBRARY_SEARCH_PATHS" => '"${PROJECT_DIR}/.symlinks/plugins/accuraemirates/ios/Classes/.."/**',
   }
   s.vendored_frameworks = 'opencv2.framework', "CoreVideo.framework", "Foundation.framework", "CoreGrpahics.framework",
   "Accelerate.framework", "CoreMedia.framework", "CoreImage.framework", "QuartzCore.framework", "AudioToolbox.framework",


### PR DESCRIPTION
If you install this plugin via a git repo, so not via path like the example project does, then the LIBRARY_SEARCH_PATHS is wrong, it cannot find the accuraemirates intermediate files: error ""ld: library not found for -lAccuraEmirate"
This change works for both