### PR TITLE
no_split

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -68,14 +68,6 @@ android {
         sourceCompatibility = '1.8'
         targetCompatibility = '1.8'
     }
-    splits {
-        abi {
-            enable true
-            reset()
-            include 'armeabi-v7a', 'arm64-v8a'/*, 'x86', 'x86_64'*/
-            universalApk true
-        }
-    }
 
 }
 


### PR DESCRIPTION
disabling split, not needed. when you run it in a clean new flutter 1.17 version you'll get:

`Gradle build failed to produce an .apk file. It's likely that this file was generated under`